### PR TITLE
Bump build number for `itemloaders`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,15 +11,17 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.5
+    - python >=3.6
     # Same order as setup.py:
     - w3lib >=1.17.0
     - parsel >=1.5.0
@@ -35,14 +37,15 @@ test:
     - pip check
 
 about:
-  home: https://github.com/scrapy/itemadapter
+  home: https://github.com/scrapy/itemloaders
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: Collect data from HTML and XML sources
   description: |
     Library that helps you collect data from HTML and XML sources.
-
+  dev_url: https://github.com/scrapy/itemloaders
+  doc_url: https://itemloaders.readthedocs.io/en/latest/
 extra:
   recipe-maintainers:
     - Gallaecio


### PR DESCRIPTION
Changelog: https://itemloaders.readthedocs.io/en/latest/release-notes.html#itemloaders-1-0-4-2020-11-12
License: https://github.com/scrapy/itemloaders/blob/v1.0.4/LICENSE
Upstream setup.py: https://github.com/scrapy/itemloaders/blob/v1.0.4/setup.py

Actions:
1. Add setuptools, wheel, 
2. Add dev, doc urls, 
3. Fix python in host and run
4. Fix home url