### PR TITLE
update to 1.1.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "itemloaders" %}
-{% set version = "1.0.4" %}
+{% set version = "1.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1277cd8ca3e4c02dcdfbc1bcae9134ad89acfa6041bd15b4561c6290203a0c96
+  sha256: 21d81c61da6a08b48e5996288cdf3031c0f92e5d0075920a0242527523e14a48
 
 build:
-  noarch: python
-  number: 1
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true # [py<37]
 
 requirements:
   host:
@@ -21,20 +21,23 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6
-    # Same order as setup.py:
+    - python
     - w3lib >=1.17.0
     - parsel >=1.5.0
     - jmespath >=0.9.5
     - itemadapter >=0.1.0
 
 test:
+  source_files:
+    - tests
   imports:
     - itemloaders
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest tests
 
 about:
   home: https://github.com/scrapy/itemloaders
@@ -45,7 +48,8 @@ about:
   description: |
     Library that helps you collect data from HTML and XML sources.
   dev_url: https://github.com/scrapy/itemloaders
-  doc_url: https://itemloaders.readthedocs.io/en/latest/
+  doc_url: https://itemloaders.readthedocs.io
+
 extra:
   recipe-maintainers:
     - Gallaecio


### PR DESCRIPTION
itemloaders 1.1.0

**Destination channel:** defaults

### Links

- PKG-4077
- https://github.com/scrapy/itemloaders/blob/v1.1.0/setup.py

### Explanation of changes:

- scrappy tests failing due to an old version of itemloaders
